### PR TITLE
Update astro.config for Astro 5.17.2

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig, fontProviders } from 'astro/config'
 import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
@@ -7,48 +7,52 @@ export default defineConfig({
   },
   experimental: {
     fonts: [{
-      provider: "local",
+      provider: fontProviders.local(),
       name: "InterLocal",
       cssVariable: "--font-inter",
-      variants: [
-        {
-          weight: 400,
-          style: "normal",
-          src: ["./src/assets/fonts/Inter-Regular.woff2"]
-        },
-        {
-          weight: 600,
-          style: "normal",
-          src: ["./src/assets/fonts/Inter-SemiBold.woff2"]
-        },
-        {
-          weight: 700,
-          style: "normal",
-          src: ["./src/assets/fonts/Inter-Bold.woff2"]
-        }
-      ]
+      options: {
+        variants: [
+          {
+            weight: 400,
+            style: "normal",
+            src: ["./src/assets/fonts/Inter-Regular.woff2"]
+          },
+          {
+            weight: 600,
+            style: "normal",
+            src: ["./src/assets/fonts/Inter-SemiBold.woff2"]
+          },
+          {
+            weight: 700,
+            style: "normal",
+            src: ["./src/assets/fonts/Inter-Bold.woff2"]
+          }]
+      }
     },
     {
-      provider: "local",
+      provider: fontProviders.local(),
       name: "InterLocalDisplay",
       cssVariable: "--font-inter-display",
-      variants: [
-        {
-          weight: 400,
-          style: "normal",
-          src: ["./src/assets/fonts/InterDisplay-Regular.woff2"]
-        },
-        {
-          weight: 500,
-          style: "normal",
-          src: ["./src/assets/fonts/InterDisplay-Medium.woff2"]
-        },
-        {
-          weight: 600,
-          style: "normal",
-          src: ["./src/assets/fonts/InterDisplay-SemiBold.woff2"]
-        }
-      ]
+
+      options: {
+        variants: [
+          {
+            weight: 400,
+            style: "normal",
+            src: ["./src/assets/fonts/InterDisplay-Regular.woff2"]
+          },
+          {
+            weight: 500,
+            style: "normal",
+            src: ["./src/assets/fonts/InterDisplay-Medium.woff2"]
+          },
+          {
+            weight: 600,
+            style: "normal",
+            src: ["./src/assets/fonts/InterDisplay-SemiBold.woff2"]
+          }
+        ]
+      }
     }]
   }
-})
+});


### PR DESCRIPTION
Fixes the theme to work with the latest version of Astro by updating the config to support changes to the experimental fonts API.